### PR TITLE
Swap Orpheus TTS for QwenTTS + voice reliability fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,8 @@ FIRECRAWL_API_KEY=
 # Teaching Website
 WEBSITE_API_KEY=
 
-# TTS (Orpheus on inference node)
-ORPHEUS_URL=http://127.0.0.1:5005
+# TTS (QwenTTS on inference node)
+QWEN_TTS_URL=http://127.0.0.1:5005
 
 # STT (Whisper on inference node)
 WHISPER_URL=http://127.0.0.1:8000

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ src/
 ├── tool-loop/            # ReAct tool-calling loop engine
 ├── ollama/               # Ollama HTTP client (chat, stream, embed)
 ├── channels/             # Pluggable adapters (Discord, Web, WhatsApp, etc.)
-├── services/             # TTS (Orpheus) and STT (Whisper) services
+├── services/             # TTS (QwenTTS) and STT (Whisper) services
 ├── tools/                # Tool implementations
 ├── agents/               # Workspace files + agent routing
 ├── context/              # Token budget, history compaction

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Each specialist gets a short system prompt and a handful of tools. Even a 30B mo
 | Messaging | `send_message` | Cross-channel message delivery |
 | Browsing | `browser` | Playwright headless Chromium — navigate, snapshot, screenshot |
 | Vision | *(automatic)* | Image analysis via multimodal model — descriptions injected into context for natural Q&A |
-| Voice | TTS/STT | Orpheus TTS + faster-whisper STT — voice in, voice out |
+| Voice | TTS/STT | QwenTTS + faster-whisper STT — voice in, voice out |
 | Multi-task | *(decomposed)* | Complex requests split into sub-tasks across specialists |
 | Heartbeat | *(autonomous)* | Scheduled autonomous task checks, memory cleanup, and status reports |
 | Context Compaction | *(automatic)* | Budget-aware history summarization with memory flush |
@@ -109,7 +109,7 @@ localclaw/
 │   ├── tool-loop/            # Tool-calling loop engine
 │   ├── ollama/               # Ollama HTTP client (chat, stream, embed)
 │   ├── channels/             # Pluggable adapters (Discord, Telegram, Web, Slack, Gmail, Microsoft Graph, WhatsApp)
-│   ├── services/             # TTS (Orpheus) and STT (Whisper) services
+│   ├── services/             # TTS (QwenTTS) and STT (Whisper) services
 │   ├── tasks/                # Task board (types + JSON/Markdown store)
 │   ├── tools/                # 22 tool implementations
 │   ├── agents/               # Workspace files + routing
@@ -152,7 +152,7 @@ Adding a new adapter requires zero core code changes — implement the interface
 LocalClaw supports voice input and output through an optional TTS/STT service layer:
 
 - **STT (Speech-to-Text)** — [faster-whisper](https://github.com/SYSTRAN/faster-whisper) server on your inference node. Incoming voice messages are automatically transcribed before processing.
-- **TTS (Text-to-Speech)** — [Orpheus TTS](https://github.com/canopyai/orpheus-tts) with [llama.cpp](https://github.com/ggerganov/llama.cpp) backend on your inference node. When a user sends a voice message, the response is synthesized back as audio.
+- **TTS (Text-to-Speech)** — [QwenTTS](https://github.com/QwenLM/Qwen2.5-Omni) on your inference node. When a user sends a voice message, the response is synthesized back as audio.
 
 Both use OpenAI-compatible HTTP APIs (no extra npm packages). The rule is simple: **voice in → voice out, text in → text out**. Adapters that don't support audio (Gmail, Microsoft Graph) gracefully ignore it.
 
@@ -170,32 +170,28 @@ The UI also includes a **New Session** button to reset conversation history.
 
 Voice interactions use a faster, lighter model (`qwen2.5:7b` by default) for chat responses to minimize latency. Tool-using categories (web search, memory, exec, etc.) still use the full specialist model for reliable tool calling. The voice model is configured in `src/orchestrator.ts` via the `VOICE_MODEL` constant.
 
-**Voice setup requires three services on your inference node:**
+**Voice setup requires two services on your inference node:**
 
-1. **llama-server** — Serves the Orpheus-3b model (port 8080)
+1. **QwenTTS** — OpenAI-compatible TTS endpoint (port 5005)
    ```bash
-   ./llama-server -m orpheus-3b-0.1-ft-q4_k_m.gguf -c 2048 -ngl 99 --flash-attn --port 8080
+   python -m qwen_tts.server --port 5005
    ```
-2. **Orpheus TTS FastAPI** — Converts LLM tokens to audio via SNAC codec (port 5005)
-   ```bash
-   cd orpheus-tts && python api/app.py
-   ```
-3. **faster-whisper** — OpenAI-compatible STT endpoint (port 8000)
+2. **faster-whisper** — OpenAI-compatible STT endpoint (port 8000)
    ```bash
    faster-whisper-server --model large-v3 --device cuda
    ```
 
-**Important:** The Orpheus FastAPI server must convert output to OGG Opus format (required for WhatsApp voice notes). Ensure ffmpeg is installed on the inference node for the WAV→Opus conversion.
+**Important:** The QwenTTS server must convert output to OGG Opus format (required for WhatsApp voice notes). Ensure ffmpeg is installed on the inference node for the WAV→Opus conversion.
 
 Configure in `.env`:
 ```env
-ORPHEUS_URL=http://your-gpu-node:5005
+QWEN_TTS_URL=http://your-gpu-node:5005
 WHISPER_URL=http://your-gpu-node:8000
 ```
 
 Enable in `localclaw.config.json5`:
 ```json5
-tts: { enabled: true, url: "${ORPHEUS_URL}", voice: "tara", format: "opus" },
+tts: { enabled: true, url: "${QWEN_TTS_URL}", voice: "serena", format: "opus" },
 stt: { enabled: true, url: "${WHISPER_URL}", model: "whisper-large-v3", language: "en" },
 ```
 
@@ -412,7 +408,7 @@ Add `"reason"` to any specialist's `tools` array to enable the reasoning pass fo
 | Scheduling | croner |
 | Vector Store | better-sqlite3 |
 | WhatsApp | @whiskeysockets/baileys |
-| TTS | Orpheus TTS (HTTP) |
+| TTS | QwenTTS (HTTP) |
 | STT | faster-whisper (HTTP) |
 | Config | JSON5 + Zod |
 | Testing | Vitest |

--- a/localclaw.config.json5
+++ b/localclaw.config.json5
@@ -210,8 +210,8 @@
 
   tts: {
     enabled: true,
-    url: "${ORPHEUS_URL}",
-    voice: "tara",
+    url: "${QWEN_TTS_URL}",
+    voice: "serena",
     format: "opus",
   },
 

--- a/src/channels/web/adapter.ts
+++ b/src/channels/web/adapter.ts
@@ -105,6 +105,11 @@ export class WebApiAdapter implements ChannelAdapter {
       'Connection': 'keep-alive',
     });
 
+    // SSE keepalive: send a comment every 15s to prevent browser/proxy timeouts
+    const keepalive = setInterval(() => {
+      res.write(': keepalive\n\n');
+    }, 15_000);
+
     const responsePromise = new Promise<MessageContent>((resolve) => {
       this.pendingResponses.set(msgId, resolve);
       setTimeout(() => {
@@ -112,7 +117,7 @@ export class WebApiAdapter implements ChannelAdapter {
           this.pendingResponses.delete(msgId);
           resolve({ text: 'Request timed out' });
         }
-      }, 120_000);
+      }, 300_000);
     });
 
     const inbound: InboundMessage = {
@@ -134,6 +139,7 @@ export class WebApiAdapter implements ChannelAdapter {
     }
 
     const response = await responsePromise;
+    clearInterval(keepalive);
 
     const donePayload: Record<string, unknown> = {
       stage: 'done',
@@ -180,7 +186,7 @@ export class WebApiAdapter implements ChannelAdapter {
           this.pendingResponses.delete(msgId);
           resolve({ text: 'Request timed out' });
         }
-      }, 120_000);
+      }, 300_000);
     });
 
     const inbound: InboundMessage = {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -147,7 +147,7 @@ export const BrowserConfigSchema = z.object({
 export const TTSConfigSchema = z.object({
   enabled: z.boolean().default(false),
   url: z.string().default('http://127.0.0.1:5005'),
-  voice: z.string().default('tara'),
+  voice: z.string().default('serena'),
   format: z.enum(['wav', 'opus', 'mp3']).default('opus'),
 });
 

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -24,7 +24,7 @@ export class CronService {
   async start(): Promise<void> {
     this.running = true;
     this.scheduleAll();
-    console.log(`[Cron] Started with ${this.store.list().length} active job(s)`);
+    console.log(`[Cron] Started with ${this.store.listByType('cron').length} cron job(s), ${this.store.listByType('heartbeat').length} heartbeat task(s)`);
   }
 
   stop(): void {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -15,6 +15,7 @@ import { resolveRoute } from './agents/resolve-route.js';
 import { registerAllTools } from './tools/register-all.js';
 import { bootstrapWorkspace } from './agents/workspace.js';
 import { resolveWorkspacePath } from './agents/scope.js';
+import type { EmbeddingStore } from './memory/embeddings.js';
 import { TTSService } from './services/tts.js';
 import { STTService } from './services/stt.js';
 import { VisionService } from './services/vision.js';
@@ -50,6 +51,7 @@ export class Orchestrator {
   private config: LocalClawConfig;
   private rateLimits = new Map<string, number[]>();
   private heartbeatCron?: Cron;
+  private embeddingStore?: EmbeddingStore;
 
   constructor(config: LocalClawConfig) {
     this.config = config;
@@ -118,13 +120,14 @@ export class Orchestrator {
     );
 
     // Register all tools
-    await registerAllTools(this.toolRegistry, this.config, {
+    const { embeddingStore } = await registerAllTools(this.toolRegistry, this.config, {
       cronService: this.cronService,
       channelRegistry: this.channelRegistry,
       ollamaClient: this.client,
       taskStore,
       heartbeatConfig: this.config.heartbeat,
     });
+    this.embeddingStore = embeddingStore;
 
     // Set up message handler
     this.channelRegistry.onMessage(async (msg) => {
@@ -161,6 +164,7 @@ export class Orchestrator {
   async stop(): Promise<void> {
     this.heartbeatCron?.stop();
     this.cronService?.stop();
+    this.embeddingStore?.close();
     await this.channelRegistry.disconnectAll();
     console.log('[Orchestrator] Stopped');
   }
@@ -214,13 +218,14 @@ export class Orchestrator {
         taskInstructions,
       ].join('\n');
 
+      // No sessionStore — heartbeat runs are stateless so the model
+      // can't pattern-match from previous (potentially hallucinated) runs
       const result = await dispatchMessage({
         client: this.client,
         registry: this.toolRegistry,
         config: this.config,
         message: prompt,
         overrideCategory: 'multi',
-        sessionStore: this.sessionStore,
       });
 
       console.log(`[Heartbeat] Completed (${result.iterations} steps)`);

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -12,7 +12,7 @@ export class TTSService {
   }
 
   /**
-   * Synthesize text to audio via Orpheus TTS (OpenAI-compatible endpoint).
+   * Synthesize text to audio via QwenTTS (OpenAI-compatible endpoint).
    * Returns audio buffer on success, null on failure or disabled.
    */
   async synthesize(text: string): Promise<Buffer | null> {
@@ -20,26 +20,29 @@ export class TTSService {
     if (!text.trim()) return null;
 
     try {
+      const payload = {
+        model: 'tts-1',
+        input: text,
+        voice: this.config.voice,
+        response_format: this.config.format,
+      };
+      console.log(`[TTS] Request: voice=${payload.voice}, format=${payload.response_format}, input=${text.length} chars`);
       const res = await fetch(`${this.config.url}/v1/audio/speech`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          model: 'orpheus',
-          input: text,
-          voice: this.config.voice,
-          response_format: this.config.format,
-        }),
+        body: JSON.stringify(payload),
       });
 
       if (!res.ok) {
-        console.error(`[TTS] Orpheus returned ${res.status}: ${res.statusText}`);
+        const body = await res.text().catch(() => '');
+        console.error(`[TTS] QwenTTS returned ${res.status}: ${res.statusText} — ${body}`);
         return null;
       }
 
       const arrayBuffer = await res.arrayBuffer();
       return Buffer.from(arrayBuffer);
     } catch (err) {
-      console.error('[TTS] Failed to reach Orpheus:', err instanceof Error ? err.message : err);
+      console.error('[TTS] Failed to reach QwenTTS:', err instanceof Error ? err.message : err);
       return null;
     }
   }

--- a/src/tools/knowledge-import.ts
+++ b/src/tools/knowledge-import.ts
@@ -3,7 +3,8 @@ import { resolve, extname, basename } from 'node:path';
 import type { LocalClawTool } from './types.js';
 import type { OllamaClient } from '../ollama/client.js';
 import type { KnowledgeConfig } from '../config/types.js';
-import { EmbeddingStore, generateMemoryId } from '../memory/embeddings.js';
+import type { EmbeddingStore } from '../memory/embeddings.js';
+import { generateMemoryId } from '../memory/embeddings.js';
 import { readDocument, chunkDocument } from '../knowledge/chunker.js';
 
 const DEFAULT_ALLOWED_EXTENSIONS = ['.pdf', '.csv', '.md', '.txt', '.html', '.htm'];
@@ -11,9 +12,9 @@ const DEFAULT_ALLOWED_EXTENSIONS = ['.pdf', '.csv', '.md', '.txt', '.html', '.ht
 export function createKnowledgeImportTool(
   workspacePath: string,
   ollamaClient: OllamaClient,
+  embeddingStore: EmbeddingStore,
   config?: KnowledgeConfig,
 ): LocalClawTool {
-  const embeddingStore = new EmbeddingStore();
   const allowedExtensions = new Set(config?.allowedExtensions ?? DEFAULT_ALLOWED_EXTENSIONS);
   const maxChunkSize = config?.maxChunkSize ?? 800;
   const overlapSize = config?.overlapSize ?? 100;

--- a/src/tools/memory-save.ts
+++ b/src/tools/memory-save.ts
@@ -3,7 +3,8 @@ import { basename, join, resolve, dirname } from 'node:path';
 import type { LocalClawTool } from './types.js';
 import type { OllamaClient } from '../ollama/client.js';
 import type { MemoryConsolidationConfig } from '../config/types.js';
-import { EmbeddingStore, generateEmbedding, generateMemoryId } from '../memory/embeddings.js';
+import type { EmbeddingStore } from '../memory/embeddings.js';
+import { generateEmbedding, generateMemoryId } from '../memory/embeddings.js';
 import { consolidateMemory } from '../memory/consolidation.js';
 
 /**
@@ -19,8 +20,8 @@ export function createMemorySaveTool(
   workspacePath: string,
   ollamaClient?: OllamaClient,
   consolidationConfig?: MemoryConsolidationConfig,
+  embeddingStore?: EmbeddingStore,
 ): LocalClawTool {
-  const embeddingStore = new EmbeddingStore();
 
   return {
     name: 'memory_save',
@@ -75,7 +76,7 @@ export function createMemorySaveTool(
 
         // Generate embedding and run consolidation before saving
         let consolidationNote = '';
-        if (ollamaClient) {
+        if (ollamaClient && embeddingStore) {
           try {
             const embedding = await generateEmbedding(ollamaClient, content);
 

--- a/src/tools/memory-search.ts
+++ b/src/tools/memory-search.ts
@@ -1,13 +1,14 @@
 import type { LocalClawTool } from './types.js';
 import type { OllamaClient } from '../ollama/client.js';
 import { searchMarkdownFiles } from '../memory/search.js';
-import { EmbeddingStore, generateEmbedding } from '../memory/embeddings.js';
+import type { EmbeddingStore } from '../memory/embeddings.js';
+import { generateEmbedding } from '../memory/embeddings.js';
 
 export function createMemorySearchTool(
   workspacePath: string,
   ollamaClient?: OllamaClient,
+  embeddingStore?: EmbeddingStore,
 ): LocalClawTool {
-  const embeddingStore = new EmbeddingStore();
 
   return {
     name: 'memory_search',
@@ -32,7 +33,7 @@ export function createMemorySearchTool(
       const source = (params.source as string) || 'all';
 
       // Try vector search first if client is available and store has entries
-      if (ollamaClient && embeddingStore.count() > 0) {
+      if (ollamaClient && embeddingStore && embeddingStore.count() > 0) {
         try {
           const queryEmbedding = await generateEmbedding(ollamaClient, query);
           const vectorResults = embeddingStore.search(

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -4,6 +4,7 @@ import type { CronService } from '../cron/service.js';
 import type { ChannelRegistry } from '../channels/registry.js';
 import type { OllamaClient } from '../ollama/client.js';
 import type { TaskStore } from '../tasks/store.js';
+import { EmbeddingStore } from '../memory/embeddings.js';
 import { resolveWorkspacePath } from '../agents/scope.js';
 import { createWebSearchTool } from './web-search.js';
 import { createWebFetchTool } from './web-fetch.js';
@@ -44,6 +45,10 @@ export interface RegisterToolsOptions {
   heartbeatConfig?: import('../config/types.js').HeartbeatConfig;
 }
 
+export interface RegisterToolsResult {
+  embeddingStore: EmbeddingStore;
+}
+
 /**
  * Register all available tools with the registry based on config.
  * Called once at startup. New tools: add registration here.
@@ -53,20 +58,24 @@ export async function registerAllTools(
   registry: ToolRegistry,
   config: LocalClawConfig,
   options?: RegisterToolsOptions,
-): Promise<void> {
+): Promise<RegisterToolsResult> {
   // Web tools
   registry.register(createWebSearchTool(config.tools?.web?.search));
   registry.register(createWebFetchTool(config.tools?.web?.fetch));
 
   // Memory tools (with embedding support if client available)
   const workspace = resolveWorkspacePath(config.agents.default, config);
-  registry.register(createMemorySearchTool(workspace, options?.ollamaClient));
+
+  // Create a single shared EmbeddingStore so all memory tools share one DB connection
+  const embeddingStore = new EmbeddingStore();
+
+  registry.register(createMemorySearchTool(workspace, options?.ollamaClient, embeddingStore));
   registry.register(createMemoryGetTool(workspace));
-  registry.register(createMemorySaveTool(workspace, options?.ollamaClient, config.memory?.consolidation));
+  registry.register(createMemorySaveTool(workspace, options?.ollamaClient, config.memory?.consolidation, embeddingStore));
 
   // Knowledge import tool (requires Ollama for embeddings)
   if (options?.ollamaClient) {
-    registry.register(createKnowledgeImportTool(workspace, options.ollamaClient, config.tools?.knowledge));
+    registry.register(createKnowledgeImportTool(workspace, options.ollamaClient, embeddingStore, config.tools?.knowledge));
   }
 
   // Docker backend (if configured)
@@ -137,4 +146,6 @@ export async function registerAllTools(
   // Workspace tools (always available)
   registry.register(createWorkspaceReadTool());
   registry.register(createWorkspaceWriteTool());
+
+  return { embeddingStore };
 }


### PR DESCRIPTION
## Summary
- Replace Orpheus TTS engine with QwenTTS across all config, source, and documentation
- Fix voice timeouts on the web UI by adding SSE keepalive pings and bumping request timeout to 5 minutes
- Share a single EmbeddingStore instance across memory tools (was creating multiple DB connections)
- Make heartbeat runs stateless to prevent hallucination carry-over between runs

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 159 tests pass
- [x] `grep -ri orpheus` — zero hits
- [x] Voice tested end-to-end on web UI (port 3100)
- [ ] Verify TTS works on WhatsApp voice notes
- [ ] Confirm heartbeat reports are cleaner without session history

🤖 Generated with [Claude Code](https://claude.com/claude-code)